### PR TITLE
Add create account hook

### DIFF
--- a/src/hooks/auth0-context.ts
+++ b/src/hooks/auth0-context.ts
@@ -18,6 +18,7 @@ import type {
   ExchangeNativeSocialOptions,
   RevokeOptions,
   ResetPasswordOptions,
+  CreateUserOptions,
 } from '../types';
 import BaseError from '../utils/baseError';
 
@@ -138,6 +139,11 @@ export interface Auth0ContextInterface<TUser extends User = User>
    *Request an email with instructions to change password of a user {@link Auth#resetPassword}
    */
   resetPassword: (parameters: ResetPasswordOptions) => Promise<void>;
+
+  /**
+   *Creates a new user with the given email and password {@link Auth#createUser}
+   */
+  createUser: (parameters: CreateUserOptions) => Promise<Partial<User>>;
 }
 
 export interface AuthState<TUser extends User = User> {
@@ -181,6 +187,7 @@ const initialContext = {
   authorizeWithExchangeNativeSocial: stub,
   revokeRefreshToken: stub,
   resetPassword: stub,
+  createUser: stub,
 };
 
 const Auth0Context = createContext<Auth0ContextInterface>(initialContext);

--- a/src/hooks/auth0-provider.tsx
+++ b/src/hooks/auth0-provider.tsx
@@ -25,6 +25,7 @@ import type {
   ExchangeNativeSocialOptions,
   RevokeOptions,
   ResetPasswordOptions,
+  CreateUserOptions,
 } from '../types';
 import type { CustomJwtPayload } from '../internal-types';
 import { convertUser } from '../utils/userConversion';
@@ -386,6 +387,19 @@ const Auth0Provider = ({
     }
   }, [client]);
 
+  const createUser = useCallback(
+    async (parameters: CreateUserOptions) => {
+      try {
+        const user = await client.auth.createUser(parameters);
+        return user;
+      } catch (error) {
+        dispatch({ type: 'ERROR', error: error as BaseError });
+        throw error;
+      }
+    },
+    [client]
+  );
+
   const contextValue = useMemo(
     () => ({
       ...state,
@@ -407,6 +421,7 @@ const Auth0Provider = ({
       authorizeWithExchangeNativeSocial,
       revokeRefreshToken,
       resetPassword,
+      createUser,
     }),
     [
       state,
@@ -428,6 +443,7 @@ const Auth0Provider = ({
       authorizeWithExchangeNativeSocial,
       revokeRefreshToken,
       resetPassword,
+      createUser,
     ]
   );
 

--- a/src/hooks/use-auth0.ts
+++ b/src/hooks/use-auth0.ts
@@ -30,6 +30,7 @@ import type { Auth0ContextInterface } from './auth0-context';
  *   authorizeWithPasswordRealm,
  *   authorizeWithExchangeNativeSocial,
  *   revokeRefreshToken
+ *   createUser
  * } = useAuth0();
  * ```
  *


### PR DESCRIPTION
### Fork Changes

Exposed the existing createUser method from react-native-auth0/src/auth/index.ts through the Auth0Context.Provider, allowing React Native components to perform native email/password signups without relying on a WebView. This aligns with existing context-based patterns in the SDK and enables a more seamless, native user experience.


### References

- ISSUE: [feature request](https://github.com/auth0/react-native-auth0/issues/1149)

### Testing

- [x] This change adds unit test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] All existing and new tests complete without errors
- [x] All active GitHub checks have passed
